### PR TITLE
fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Python 2.7.8 (default, Apr  6 2015, 16:25:30)
 In [1]: %load_ext trepanmagic
 trepanmagic.py loaded
 In [2]: import os.path
-In [3]: %trepan_eval(os.path.join('foo', 'bar'))
+In [3]: %trepan_eval os.path.join('foo', 'bar')
 (/tmp/eval_stringS9ST2e.py:1 remapped <string>): <module>
 -> 1 (os.path.join('foo', 'bar'))
 (trepan2) s


### PR DESCRIPTION
not sure if perhaps it worked with ipython2, with ipython3 it fails `UsageError: Line magic function %trepan_eval(os.path.join('foo', not found.` removing `()` it now works.