### PR TITLE
add setup.py and update install and the rest of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,31 @@ IPython extension for using the [python trepan](https://pypi.python.org/pypi?:ac
 
 ## Installation
 
-To install execute the the following code snippet in an IPython shell or IPython notebook cell:
+Normal installation is via pip:
 
 ```
-    %install_ext https://raw.github.com/rocky/ipython-trepan/master/trepanmagic.py
-    %load_ext trepanmagic
+pip install git+https://github.com/rocky/ipython-trepan
 ```
 
-or put *trepanmagic.py* in `$HOME/.python/profile_default/startup`:
+If you'd like the extension to be loaded automatically you can put the extension file directly under your
+ `$HOME/.ipython/profile_default/startup`, by doing:
+
 
 ```
-    cd `$HOME/.python/profile_default/startup`:
+    cd $HOME/.ipython/profile_default/startup
     wget https://raw.github.com/rocky/ipython-trepan/master/trepanmagic.py
 ```
+Now `ipython` will load it automatically every time it starts.
 
 ## Usage
 
-IPython magic functions that are added:
+First load the extension in an IPython shell or IPython notebook cell:
+
+```
+    %load_ext trepanmagic
+```
+
+This adds the following IPython magic functions:
 
  * `%trepan_eval` &ndash; evaluate a Python statement under the debugger
  * `%trepan` &ndash; run the debugger on a Python program
@@ -30,25 +38,29 @@ IPython magic functions that are added:
 ### Example
 
 ```
-$ ipython
-Python 2.7.8 (default, Apr  6 2015, 16:25:30)
-...
+ipython
+Python 3.7.5 (default, Oct 25 2019, 15:51:11)
+Type 'copyright', 'credits' or 'license' for more information
+IPython 7.13.0 -- An enhanced Interactive Python. Type '?' for help.
 
 In [1]: %load_ext trepanmagic
+
 trepanmagic.py loaded
-In [2]: import os.path
+
+In [2]:  import os.path
+
 In [3]: %trepan_eval os.path.join('foo', 'bar')
-(/tmp/eval_stringS9ST2e.py:1 remapped <string>): <module>
--> 1 (os.path.join('foo', 'bar'))
-(trepan2) s
-(/home/rocky/.pyenv/versions/2.7.8/lib/python2.7/posixpath.py:68): join
--> 68 def join(a, *p):
-(trepan2) s
-(/home/rocky/.pyenv/versions/2.7.8/lib/python2.7/posixpath.py:73): join
--- 73     path = a
-(trepan2) c
+(<string>:1 remapped <string>): <module>
+(trepan3k) s
+(/home/stas/anaconda3/envs/main/lib/python3.7/posixpath.py:75): join
+-> 75 def join(a, *p):
+a = 'foo'
+p = ('bar',)
+(trepan3k) s
+(/home/stas/anaconda3/envs/main/lib/python3.7/posixpath.py:80): join
+-- 80     a = os.fspath(a)
+(trepan3k) c
 Out[3]: 'foo/bar'
-In [4]:
 ```
 
 See also the [examples](https://github.com/rocky/ipython-trepan/tree/master/examples) directory.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+setup(
+    name='trepanmagic',
+    version='0.1.0',
+    py_modules=['trepanmagic'],
+    install_requires=[ 'trepan3k', ],
+)


### PR DESCRIPTION
The current installation instructions don't work with python3 - there is no `%install_ext` and it can't be loaded in jupyter notebook. I added `setup.py`, and updated `README.md` - the package can now be installed and loaded in either ipython or jupyter notebooks. it will also automatically install `trepan3k`.

Note, if you'd like to put it on pypi, you just need to run a few lines in this section after you created an account on pypi:
https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives
but it's totally fine to leave it as is on github.